### PR TITLE
Add support for the `error`, `xfailed` and `xpassed` statuses

### DIFF
--- a/examples/test_all_statuses.py
+++ b/examples/test_all_statuses.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+
+@pytest.fixture
+def broken_fixture():
+    raise Exception('Trigger an error in any test which uses this fixture')
+
+
+def test_pass():
+    """All statuses :: This test passes"""
+    assert True
+
+
+def test_fail():
+    """All statuses :: This test fails"""
+    assert False
+
+
+def test_error(broken_fixture):
+    """All statuses :: This test has a broken fixture which raises an error"""
+    assert True
+
+
+@pytest.mark.skip
+def test_skip():
+    """All statuses :: This test is skipped"""
+    assert True
+
+
+@pytest.mark.xfail
+def test_xfail():
+    """All statuses :: This test is expected to fail and does"""
+    assert False
+
+
+@pytest.mark.xfail
+def test_xpass():
+    """All statuses :: This test is expected to fail but actually passes"""
+    assert True

--- a/pytest_mocha/reporter.py
+++ b/pytest_mocha/reporter.py
@@ -9,12 +9,18 @@ STORAGE = {
 STATUS_ICONS = {
     'passed': '✓',
     'failed': '✖',
-    'skipped': '!'
+    'skipped': '!',
+    'error': 'E',
+    'xfailed': '✖',
+    'xpassed': '✓',
 }
 COLORS = {
     'passed': Fore.GREEN,
     'failed': Fore.RED,
-    'skipped': Fore.YELLOW
+    'skipped': Fore.YELLOW,
+    'error': Fore.RED,
+    'xfailed': Fore.YELLOW,
+    'xpassed': Fore.YELLOW,
 }
 
 


### PR DESCRIPTION
Fix an `INTERNALERROR` which happens when a test returns the `error`, `xfailed` or
`xpassed` status.