### PR TITLE
Fix pytest warning on deprecated imp module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.4.0
+
+* Drop support for python 2
+* Fix warning with pytest>=5.4.0 (imp module)
+
 ## v0.3.0
 
 * Add support for test arguments

--- a/pytest_mocha/plugin.py
+++ b/pytest_mocha/plugin.py
@@ -20,10 +20,10 @@ def pytest_addoption(parser):
 
 def pytest_configure(config):
     if config.option.mocha and not config.option.mocha_disable:
-        import imp
+        import importlib
         import _pytest
         _pytest.terminal.TerminalReporter \
             .pytest_runtest_logstart = logstart_replacer
         _pytest.terminal.TerminalReporter \
             .pytest_runtest_logreport = report_replacer
-        imp.reload(_pytest)
+        importlib.reload(_pytest)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as f:
 
 setup(
     name='pytest-mocha',
-    version='0.3.0',
+    version='0.4.0',
     description='pytest plugin to display test execution output like a mochajs',
     long_description=long_description,
     author='Rudinei Goi Roecker',
@@ -16,6 +16,7 @@ setup(
     packages=['pytest_mocha'],
     install_requires=[
         'colorama>=0.3.9',
+        "pytest >= 5.4.0",
     ],
     entry_points={
         'pytest11': ['pytest_mocha = pytest_mocha.plugin']
@@ -26,12 +27,12 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Software Development :: Testing',
         'Topic :: Software Development :: Libraries',
         'Topic :: Utilities',


### PR DESCRIPTION
Hola Rudinei,
The `imp` python module is deprecated and pytest has started throwing warnings about it in
version 5.4.0 (released 2020-03-12). This PR is a small update for this.

Unfortunately it means support must be dropped for python2. Hopefully that's okay as python2 is no longer being developed.