### PR TITLE
Issue 5: Dbl colons in test names

### DIFF
--- a/pytest_mocha/loader.py
+++ b/pytest_mocha/loader.py
@@ -86,7 +86,7 @@ def load_func(module_name, class_name, func_name):
 
 
 def load_test_info(nodeid):
-    data = nodeid.split('::')
+    data = nodeid.split('::', 1)
     file_name = data[0]
     class_name = ''
     func_name = ''

--- a/pytest_mocha/reporter.py
+++ b/pytest_mocha/reporter.py
@@ -40,7 +40,7 @@ def report_replacer(self, report):
 
     file_name, text = load_test_info(report.nodeid)
     orig_text = text
-    text = [x.strip() for x in text.split('::')]
+    text = [x.strip() for x in text.split('::', 1)]
     parents = []
     if len(text) >= 1:
         parents.extend(text[:-1])


### PR DESCRIPTION
This will allow users to use double (or triple, quadruple, etc.) colons in their test names without raising errors during reporting.